### PR TITLE
fixes started reviews

### DIFF
--- a/spec/compare-reviewers.spec.js
+++ b/spec/compare-reviewers.spec.js
@@ -219,4 +219,33 @@ describe("Compare Reviewers", function() {
     expect(needsReview).toEqual([]);
     expect(incompleteReviews).toEqual(true);
   });
+
+  it('only includes completed reviews for a codeowner who left a comment or requested changes and later approved', function() {
+    let currentReviews = [
+      { reviewer: '@codeowner1', state: 'COMMENT' },
+      { reviewer: '@codeowner1', state: 'APPROVED' },
+      { reviewer: '@codeowner2', state: 'CHANGES_REQUESTED' },
+      { reviewer: '@codeowner2', state: 'APPROVED' },
+      { reviewer: '@codeowner5', state: 'COMMENT' }
+    ];
+
+    let { completedReviews, startedReviews, needsReview, incompleteReviews } = compareReviewers(
+      currentReviews,
+      requiredReviewers,
+      minReviewers
+    );
+    expect(completedReviews).toEqual([
+      { files: 'pow/pop/*', codeowners: [ '@codeowner1' ] },
+      { files: '*.js', codeowners: [ '@codeowner2' ] },
+      { files: '/woot/yip', codeowners: [ '@codeowner1' ] }
+    ])
+    expect(startedReviews).toEqual([
+      { files: '*.js', codeowners: [ '@codeowner5' ] },
+    ])
+    expect(needsReview).toEqual([
+      { files: 'pow/pop/*', codeowners: [ '@codeowner3' ] },
+      { files: '*.js', codeowners: [ '@codeowner3', '@codeowner6' ] }
+    ])
+    expect(incompleteReviews).toEqual(true);
+  });
 });

--- a/src/compare-reviewers.js
+++ b/src/compare-reviewers.js
@@ -29,8 +29,11 @@ function compareReviewers(currentReviews, requiredReviewers, minReviewers) {
     // Set of codeowners that approved the PR
     let approvalIntersection = new Set([...approvalsSet].filter(r => requiredSet.has(r)));
 
-    // Set of codeowners that have started a review on the PR
-    let startedIntersection = new Set([...startedSet].filter(r => requiredSet.has(r)));
+    // Set of codeowners that have started a review on the PR but have not approved it
+    let startedIntersection = new Set([...startedSet]
+      .filter(r => requiredSet.has(r))
+      .filter(r => !approvalIntersection.has(r))
+    );
 
     // min reviewers for the files
     let min = minReviewers;


### PR DESCRIPTION
This PR:
* fixes a bug where reviewers who left a comment and later approved a PR still appeared in the `startedReviews` list
* removes approving reviewers from started reviewers 