### PR TITLE
updates ignore teams and fixes min reviewers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ Overview:
 * This Action can be used to ensure that a minimum number of code owners has reviewed the pull request before it is merged.
   * Required code owners will be pulled from the `CODEOWNERS` file in the default branch of the repository.
   * The workflow will fail until the minimum number of code owner reviews have been completed.
-    * The workflow logs will list completed, started, and needed code owner reviews.
+  * The workflow logs will list completed, started, and needed code owner reviews.
   * The minimum number of required code owner reviews can be set. It will default to 2 when it is not set or set to a number smaller than 2.
+  * Team codeowners are ignored by default. To include team codeowners, set `include_teams` to `true` AND set `TOKEN` to a personal access token (PAT). A PAT is required when including teams because the GITHUB_TOKEN does not have access to individual team members for comparison to PR reviewers.
 
 Limitations:
 * This Action ingores exceptions to code owner requirements. If some files in a subdirectory are excepted from code owner review in the `CODEOWNERS` file, this action will not take the exceptions into account and will require review.
@@ -19,8 +20,10 @@ Limitations:
 
 Details:
 * Required input for the workflow:
-  * `GITHUB_TOKEN`
+  * `TOKEN` - GITHUB_TOKEN or PAT.
   * `min_reviewers` - minimum number of codeowner reviewers required per any set of codeowner files; set to 2 or greater (will default to 2, if set to value less than 2)
+* Optional input:
+  * `include_teams` - defaults to `false`. Set to `true` to include teams AND set `TOKEN` to a PAT.
 * Workflow will succeed with notice when a CODEOWNERS file is not found.
 
 Sample Output for Successful Check:
@@ -67,13 +70,12 @@ jobs:
     runs-on: ubuntu-latest
     name: Codeowner Reviews
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
       - name: Check Reviews
         uses: lmnleaf/codeowner-reviewer-check
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
           min_reviewers: 3
+          include_teams: false
 ```
 
 Recommendation: Set branch protections/repo rules that require code owner review and run this workflow on `pull_request_review`.

--- a/action.yml
+++ b/action.yml
@@ -2,14 +2,14 @@ name: 'Reviewer Check'
 description: 'Checks for more than one Codeowner reviewer on a PR.'
 
 inputs:
-  GITHUB_TOKEN:
-    description: 'GitHub Token'
+  TOKEN:
+    description: 'GitHub Token or Personal Access Token - must use PAT when include_teams is set to `true`.'
     required: true
   min_reviewers:
-    description: 'Minimum number of codeowner reviews'
+    description: 'Minimum number of codeowner reviews.'
     required: true
-  ignore_teams:
-    description: 'Ignore team codeowners, i.e., only consider individual codeowners'
+  include_teams:
+    description: 'Set to `true` to include team codeowners; when include_teams is set to `false` or NOT set, team codeowners will be ignored.'
     required: false
 
 runs:

--- a/dist/index.js
+++ b/dist/index.js
@@ -9824,22 +9824,23 @@ const codeownerReviewerCheck = __nccwpck_require__(9967)
 
 async function main() {
   try {
-    const token = core.getInput('GITHUB_TOKEN');
+    const token = core.getInput('TOKEN');
     const octokit = new github.getOctokit(token);
 
     const minReviewers = core.getInput('min_reviewers');
-    const ignoreTeams = core.getInput('min_reviewers') || false;
+    const includeTeams = core.getInput('include_teams') || false;
 
     const reviewerCheck = await codeownerReviewerCheck(
       octokit,
       context,
       minReviewers,
-      ignoreTeams
+      includeTeams
     );
 
     // log codeowner reviews
+    core.info(reviewerCheck.reviewInfo.info);
+
     if (reviewerCheck.reviewsNeeded) {
-      core.info(reviewerCheck.reviewInfo.info);
       return core.setFailed(reviewerCheck.reviewInfo.error);
     }
 

--- a/index.js
+++ b/index.js
@@ -6,22 +6,23 @@ const codeownerReviewerCheck = require('../src/codeowner-reviewer-check.js')
 
 async function main() {
   try {
-    const token = core.getInput('GITHUB_TOKEN');
+    const token = core.getInput('TOKEN');
     const octokit = new github.getOctokit(token);
 
     const minReviewers = core.getInput('min_reviewers');
-    const ignoreTeams = core.getInput('min_reviewers') || false;
+    const includeTeams = core.getInput('include_teams') || false;
 
     const reviewerCheck = await codeownerReviewerCheck(
       octokit,
       context,
       minReviewers,
-      ignoreTeams
+      includeTeams
     );
 
     // log codeowner reviews
+    core.info(reviewerCheck.reviewInfo.info);
+
     if (reviewerCheck.reviewsNeeded) {
-      core.info(reviewerCheck.reviewInfo.info);
       return core.setFailed(reviewerCheck.reviewInfo.error);
     }
 

--- a/spec/codeowner-reviewer-check.spec.js
+++ b/spec/codeowner-reviewer-check.spec.js
@@ -9,7 +9,7 @@ describe("Codeowner Reviewer Check", function() {
     repo: 'repo-name'
   };
   let minReviewers = 2;
-  let ignoreTeams = false;
+  let includeTeams = true;
 
   let codeowners = `# Codeowners
   pow/pop/* @codeowner1
@@ -41,7 +41,7 @@ describe("Codeowner Reviewer Check", function() {
       }));
     });
 
-    let reviewerCheck = await codeownerReviewerCheck(octokit, context, minReviewers, ignoreTeams);
+    let reviewerCheck = await codeownerReviewerCheck(octokit, context, minReviewers, includeTeams);
 
     expect(reviewerCheck.reviewsNeeded).toEqual(true);
     expect(reviewerCheck.reviewInfo).toEqual(reviewInfo);
@@ -53,7 +53,7 @@ describe("Codeowner Reviewer Check", function() {
     });
 
     let reviewInfo = { info: null, error: null, success: 'NO CODEOWNERS FOUND' }
-    let reviewerCheck = await codeownerReviewerCheck(octokit, context, minReviewers, ignoreTeams);
+    let reviewerCheck = await codeownerReviewerCheck(octokit, context, minReviewers, includeTeams);
 
     expect(reviewerCheck.reviewsNeeded).toEqual(false);
     expect(reviewerCheck.reviewInfo).toEqual(reviewInfo);
@@ -74,14 +74,14 @@ describe("Codeowner Reviewer Check", function() {
       }));
     });
 
-    let reviewerCheck = await codeownerReviewerCheck(octokit, context, minReviewers, ignoreTeams);
+    let reviewerCheck = await codeownerReviewerCheck(octokit, context, minReviewers, includeTeams);
 
     expect(reviewerCheck.reviewsNeeded).toEqual(true);
     expect(reviewerCheck.reviewInfo).toEqual(reviewInfo);
   });
 
-  it('ignores teams when ignoreTeams is true', async function() {
-    let ignoreTeams = true;
+  it('ignores teams when includeTeams is false', async function() {
+    let includeTeams = false;
 
     let mockBody = new Readable();
     mockBody.push(codeowners);
@@ -100,7 +100,7 @@ describe("Codeowner Reviewer Check", function() {
       error: '\u001b[1mCodeowner reviews are needed. Please ask Codeowners to complete their reviews.',
       success: '\u001b[1mAll required Codeowner reviews have been completed. Thank you! \n'
     };
-    let reviewerCheck = await codeownerReviewerCheck(octokit, context, minReviewers, ignoreTeams);
+    let reviewerCheck = await codeownerReviewerCheck(octokit, context, minReviewers, includeTeams);
 
     expect(reviewerCheck.reviewsNeeded).toEqual(true);
     expect(reviewerCheck.reviewInfo).toEqual(reviewInfo);
@@ -112,7 +112,7 @@ describe("Codeowner Reviewer Check", function() {
     });
 
     try {
-      let reviewerCheck = await codeownerReviewerCheck(octokit, context, minReviewers, ignoreTeams);
+      let reviewerCheck = await codeownerReviewerCheck(octokit, context, minReviewers, includeTeams);
     } catch (error) {
       expect(error).toEqual(new Error('fetch error'));
     }

--- a/spec/compare-reviewers.spec.js
+++ b/spec/compare-reviewers.spec.js
@@ -1,12 +1,12 @@
 const compareReviewers = require("../src/compare-reviewers.js");
 
 describe("Compare Reviewers", function() {
-  const requiredReviewers = [
+  let requiredReviewers = [
     { files: 'pow/pop/*', requiredReviewers: [ '@codeowner1', '@codeowner3' ] },
     { files: '*.js', requiredReviewers: [ '@codeowner2', '@codeowner3', '@codeowner5', '@codeowner6' ] },
     { files: '/woot/yip', requiredReviewers: [ '@codeowner1' ] }
   ]
-  const minReviewers = 2;
+  let minReviewers = 2;
 
   it('returns reviews that have been completed by codeowners', function() {
     let currentReviews = [
@@ -159,8 +159,14 @@ describe("Compare Reviewers", function() {
   });
 
   it('requires at least the minimum approved reviews unless total codeowners are fewer than the minumum', function() {
+    let requiredReviewers = [
+      { files: 'pow/pop/*', requiredReviewers: [ '@codeowner1', '@codeowner3' ] },
+      { files: '/woot/yip', requiredReviewers: [ '@codeowner1' ] }
+    ]
+    let minReviewers = 3;
     let currentReviews = [
-      { reviewer: '@codeowner1', state: 'APPROVED' }
+      { reviewer: '@codeowner1', state: 'APPROVED' },
+      { reviewer: '@codeowner3', state: 'APPROVED' }
     ]
     let { completedReviews, startedReviews, needsReview, incompleteReviews } = compareReviewers(
       currentReviews,
@@ -168,15 +174,12 @@ describe("Compare Reviewers", function() {
       minReviewers
     );
     expect(completedReviews).toEqual([
-      { files: 'pow/pop/*', codeowners: ['@codeowner1'] },
-      { files: '/woot/yip', codeowners: ['@codeowner1'] }
+      { files: 'pow/pop/*', codeowners: ['@codeowner1', '@codeowner3'] },
+      { files: '/woot/yip', codeowners: [ '@codeowner1' ] }
     ]);
     expect(startedReviews).toEqual([])
-    expect(needsReview).toEqual([
-      { files: 'pow/pop/*', codeowners: ['@codeowner3'] },
-      { files: '*.js', codeowners: ['@codeowner2', '@codeowner3', '@codeowner5', '@codeowner6'] }
-    ]);
-    expect(incompleteReviews).toEqual(true);
+    expect(needsReview).toEqual([]);
+    expect(incompleteReviews).toEqual(false);
   });
 
   it("does NOT require reviews when their aren't any codeowners", function() {

--- a/spec/prepare-codeowner-content.spec.js
+++ b/spec/prepare-codeowner-content.spec.js
@@ -46,13 +46,13 @@ describe("Prepare Codeowner Content", function() {
   ];
 
   it('preps codeowner content for comparision to PR files', async function() {
-    let ignoreTeams = false;
-    let preparedContent = await prepareCodeownerContent(content, ignoreTeams, octokit);
+    let includeTeams = true;
+    let preparedContent = await prepareCodeownerContent(content, includeTeams, octokit);
     expect(preparedContent).toEqual(codeownerInfo);
   });
 
-  it('preps codeowner content when ignoreTeams is true', async function() {
-    let ignoreTeams = true;
+  it('preps codeowner content when includeTeams is true', async function() {
+    let includeTeams = false;
     let noTeamsInfo = codeownerInfo.map(info => {
       if(info.patternMatch === 'wow/') {
         return {
@@ -64,7 +64,7 @@ describe("Prepare Codeowner Content", function() {
         return info;
       }
     });
-    let preparedContent = await prepareCodeownerContent(content, ignoreTeams, octokit);
+    let preparedContent = await prepareCodeownerContent(content, includeTeams, octokit);
     expect(preparedContent).toEqual(noTeamsInfo);
   });
 });

--- a/spec/set-owners.spec.js
+++ b/spec/set-owners.spec.js
@@ -1,38 +1,59 @@
 const setOwners = require('../src/set-owners.js');
 const Moctokit = require('./support/moctokit.js');
+const core = require('@actions/core');
 
-describe("Prepare Codeowner Content", function() {
+describe("Set Owners", function() {
   let octokit = new Moctokit();
-  let ignoreTeams = false;
+  let includeTeams = true;
 
   it('sets owners', async function () {
-    let contentOwners = [ '@codeowner1', '@codeowner2' ]
-    let owners = await setOwners(contentOwners, ignoreTeams, octokit);
+    let contentOwners = [ '@codeowner1', '@codeowner2' ];
+    let owners = await setOwners(contentOwners, includeTeams, octokit);
     expect(owners).toEqual([ '@codeowner1', '@codeowner2' ]);
   });
 
   it('sets owners with teams', async function() {
-    let contentOwners = [ '@codeowner1', '@codeowner2', '@org/team' ]
-    let owners = await setOwners(contentOwners, ignoreTeams, octokit);
+    let contentOwners = [ '@codeowner1', '@codeowner2', '@org/team' ];
+    let owners = await setOwners(contentOwners, includeTeams, octokit);
     expect(owners).toEqual([ '@codeowner1', '@codeowner2', '@codeowner7', '@codeowner8' ]);
   });
 
-  it('ignores teams when ignoreTeams is true', async function() {
-    let ignoreTeams = true;
-    let contentOwners = [ '@codeowner1', '@codeowner2', '@org/team' ]
-    let owners = await setOwners(contentOwners, ignoreTeams, octokit);
+  it('makes a request to list members for a team', async function() {
+    spyOn(octokit.rest.teams, 'listMembersInOrg').and.callThrough();
+    let contentOwners = [ '@codeowner1', '@codeowner2', '@org/team' ];
+    let owners = await setOwners(contentOwners, includeTeams, octokit);
+
+    expect(octokit.rest.teams.listMembersInOrg).toHaveBeenCalledWith({
+      org: 'org',
+      team_slug: 'team'
+    });
+  })
+
+  it('continues without team members when team not found', async function() {
+    spyOn(octokit.rest.teams, 'listMembersInOrg').and.callFake(function() {
+      return Promise.reject(new Error('Not Found'));
+    });
+    let contentOwners = [ '@codeowner1', '@codeowner2', '@org/team' ];
+    let owners = await setOwners(contentOwners, includeTeams, octokit);
+    expect(owners).toEqual([ '@codeowner1', '@codeowner2' ]);
+  });
+
+  it('ignore teams when includeTeams is false', async function() {
+    let includeTeams = false;
+    let contentOwners = [ '@codeowner1', '@codeowner2', '@org/team' ];
+    let owners = await setOwners(contentOwners, includeTeams, octokit);
     expect(owners).toEqual([ '@codeowner1', '@codeowner2' ]);
   });
 
   it('ignores email addresses', async function() {
-    let contentOwners = [ '@codeowner1', '@codeowner2', 'dev@example.com' ]
-    let owners = await setOwners(contentOwners, ignoreTeams, octokit);
+    let contentOwners = [ '@codeowner1', '@codeowner2', 'dev@example.com' ];
+    let owners = await setOwners(contentOwners, includeTeams, octokit);
     expect(owners).toEqual([ '@codeowner1', '@codeowner2' ]);
   });
 
   it('removes duplicate codeowners', async function () {
-    let contentOwners = [ '@codeowner1', '@codeowner1', '@codeowner2', '@codeowner7', '@org/team' ]
-    let owners = await setOwners(contentOwners, ignoreTeams, octokit);
+    let contentOwners = [ '@codeowner1', '@codeowner1', '@codeowner2', '@codeowner7', '@org/team' ];
+    let owners = await setOwners(contentOwners, includeTeams, octokit);
     expect(owners).toEqual([ '@codeowner1', '@codeowner2', '@codeowner7', '@codeowner8' ]);
   });
 });

--- a/src/codeowner-reviewer-check.js
+++ b/src/codeowner-reviewer-check.js
@@ -4,7 +4,7 @@ const setRequiredReviewers = require('./set-required-reviewers.js');
 const compareReviewers = require('./compare-reviewers.js');
 const prepareReviewInfo = require('./prepare-review-info.js');
 
-async function codeownerReviewerCheck(octokit, context, minReviewers, ignoreTeams) {
+async function codeownerReviewerCheck(octokit, context, minReviewers, includeTeams) {
   try {
     const codeownerContent = await getCodeownerContent(octokit, context)
     .then((info) => {
@@ -47,7 +47,7 @@ async function codeownerReviewerCheck(octokit, context, minReviewers, ignoreTeam
     })
 
     // prepare codeowner content so codeowner files can be compared to the PR files
-    const codeownerInfo = await prepareCodeownerContent(codeownerContent, ignoreTeams, octokit);
+    const codeownerInfo = await prepareCodeownerContent(codeownerContent, includeTeams, octokit);
 
     // set the required reviewers for the PR
     const requiredReviewers = setRequiredReviewers(codeownerInfo, prFilePaths);

--- a/src/compare-reviewers.js
+++ b/src/compare-reviewers.js
@@ -37,7 +37,7 @@ function compareReviewers(currentReviews, requiredReviewers, minReviewers) {
 
     // min reviewers for the files
     let min = minReviewers;
-    if (requiredSet.size < 2) {
+    if (requiredSet.size < min) {
       min = requiredSet.size
     }
 

--- a/src/prepare-codeowner-content.js
+++ b/src/prepare-codeowner-content.js
@@ -1,6 +1,6 @@
 const setOwners = require('./set-owners.js');
 
-async function prepareCodeownerContent(content, ignoreTeams, octokit) {
+async function prepareCodeownerContent(content, includeTeams, octokit) {
   // remove comments from CODEOWNERS content
   let filteredLines = content.split(/\s*$\s*/m)
     .filter((line) => !line.startsWith('#') && line !== '');
@@ -10,7 +10,7 @@ async function prepareCodeownerContent(content, ignoreTeams, octokit) {
   for (const line of filteredLines) {
     // split the codeowners line on the first space
     let [first, ...last] = line.split(/\s+/);
-    const owners = await setOwners(last, ignoreTeams, octokit)
+    const owners = await setOwners(last, includeTeams, octokit)
     .then((info) => {
       return info;
     }).catch((error) => {

--- a/src/set-owners.js
+++ b/src/set-owners.js
@@ -1,4 +1,4 @@
-async function setOwners(contentOwners, ignoreTeams, octokit) {
+async function setOwners(contentOwners, includeTeams, octokit) {
     // filter out email owners
     let nonEmailOwners = contentOwners.filter((owner) => 
       !owner.match(/^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/)
@@ -6,7 +6,7 @@ async function setOwners(contentOwners, ignoreTeams, octokit) {
 
     let owners = nonEmailOwners.filter((owner) => !owner.includes('/'));
 
-    if (ignoreTeams) {
+    if (!includeTeams) {
       return [...new Set(owners)];
     }
 


### PR DESCRIPTION
This PR: 
* updates ignore teams to default to true
  * Notes:
     * opted to have `ignore_teams` default to `true` so Action will default to using the `GITHUB_TOKEN` instead of a PAT
     * looking up team members in an org requires a PAT
* fixes a min reviewers bug where min reviewers was always assumed to be 2
